### PR TITLE
Fix Python syntax error in test_websocket.py

### DIFF
--- a/libs/websocket/tests/test_websocket.py
+++ b/libs/websocket/tests/test_websocket.py
@@ -11,7 +11,7 @@ import socket
 import ChromeREPL.libs.six as six
 
 # websocket-client
-import ChromeREPL.libs.websocket as websocket as ws
+import ChromeREPL.libs.websocket as ws
 from ChromeREPL.libs.websocket._handshake import _create_sec_websocket_key, \
     _validate as _validate_header
 from ChromeREPL.libs.websocket._http import read_headers


### PR DESCRIPTION
flake8 testing of https://github.com/acarabott/ChromeREPL

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./libs/websocket/tests/test_websocket.py:14:48: E999 SyntaxError: invalid syntax
import ChromeREPL.libs.websocket as websocket as ws
                                               ^
1     E999 SyntaxError: invalid syntax
1
```